### PR TITLE
Embedposting Iframe: Level 1 iframe works in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   
   <ul>
       <li><a href="test_pages/embedposting_iframes.html">Embed-posting iframes</a>: Embed-posting supports nested iframes. This page tests whether it works well.</li>
-      <li><a href="test_pages/embedposting_proxy.html">Embed-posting proxy</a>: Embed-posting supports forwarding submit button and ENTER keyboard event to the original form on the host page. This page tests whether it works correctly.</li>
+      <li><a href="test_pages/seamlessposting_forward.html">Keyboard forwarding</a>: Seamless-posting supports forwarding ENTER keyboard event to the original form on the host page. This page tests whether it works correctly.</li>
       <li><a href="test_pages/url_parameters.html">URL Parameters</a>: Privly links support directives for the extension. This page checks the behavior of the links.</li>
       <li><a href="test_pages/whitelist.html">Whitelist</a>: Privly has a default list of trusted domains. This page ensures that all the trusted domains are handled consistently</li>
       <li><a href="test_pages/nonwhitelist.html">Non-Whitelisted</a>: Non-trusted domains can indicate their support of Privly injection. This page checks their behavior.</li>

--- a/test_pages/embedposting_iframes.html
+++ b/test_pages/embedposting_iframes.html
@@ -10,10 +10,14 @@
       // 1 level iframe
       (function () {
         var iframe = document.createElement('iframe');
+        iframe.id = "test2_iframe";
         iframe.style.width = '200px';
         iframe.style.height = '100px';
         $('#test2').append(iframe);
-        iframe.contentWindow.document.body.innerHTML = '<textarea style="width: 150px; height: 70px;"></textarea>';
+        var html = '<html><body><textarea id="test2_textarea" style="width: 150px; height: 70px;"></textarea></body></html>';
+        iframe.contentWindow.document.open();
+        iframe.contentWindow.document.write(html);
+        iframe.contentWindow.document.close();
       }());
 
       // 2 level iframe
@@ -46,7 +50,7 @@
     <p>This file contains a test cases for different circumstances in which the Privly embed-posting dialog should always appear correctly. Even when the editable element is inside an iframe or nested iframes, the embed-posting dialog should appear on top of any other contents in the webpage.</p>
     <p>Test cases are intended to be tested automatically.<br>To test it manually, please click the Privly posting button in each editable element. The embed-posting dialog should always appear.</p>
     <h4>1. Editable element in the top frame</h4>
-    <div id="test1"><textarea style="width: 150px; height: 70px;"></textarea></div>
+    <div id="test1"><textarea id="test1_textarea" style="width: 150px; height: 70px;"></textarea></div>
     <br><hr>
 
     <h4>2. Editable element inside an iframe</h4>

--- a/test_pages/seamlessposting_forward.html
+++ b/test_pages/seamlessposting_forward.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8" />
-  <title>Privly Embed-posting Proxy Test File</title>
+  <title>Privly Seamless-posting Keyboard Forwarding Test File</title>
   <link href="../embed_posting.css" media="screen" rel="stylesheet" type="text/css" />
   <script src="../jquery-1.7.1.min.js" type="text/javascript"></script>
   <script type="text/javascript">
@@ -148,27 +148,7 @@
       }());
 
 
-      // Test case 4: Google Groups, Google Mail
-      // Nothing special in this test case :-)
-      (function () {
-        $('#test4 [role="button"]').click(function () {
-          $('#test4 [role="textbox"]').html('');
-          $('#test4').append('<div>submitted</div>');
-        });
-      }());
-
-
-      // Test case 5: Google Plus
-      // contenteditable="plaintext-only"
-      (function () {
-        $('#test5 [role="button"]').click(function () {
-          $('#test5 [role="textbox"]').html('');
-          $('#test5').append('<div>submitted</div>');
-        });
-      }());
-
-
-      // Test case 6: Twitter
+      // Test case 4: Twitter
       // Twitter collapse tweetbox when there is no content
       // Comments below are the original code from Twitter
       // 
@@ -211,36 +191,36 @@
 
       (function () {
         function condense() {
-          $('#test6 [role="textbox"]').empty().css('height', '30px');;
+          $('#test4 [role="textbox"]').empty().css('height', '30px');;
         }
         function send() {
           condense();
-          $('#test6').append('<div>submitted</div>');
-          $('#test6 [role="textbox"]').blur();
+          $('#test4').append('<div>submitted</div>');
+          $('#test4 [role="textbox"]').blur();
         }
 
-        $('#test6 [role="textbox"]').focusin(function () {
+        $('#test4 [role="textbox"]').focusin(function () {
           $(this).css('height', '70px');
         });
 
-        $('#test6 [role="textbox"]').focusout(function () {
+        $('#test4 [role="textbox"]').focusout(function () {
           if ($(this).text().trim().length === 0) {
             condense();
           }
         });
 
-        $('#test6 [role="textbox"]').keydown(function (ev) {
+        $('#test4 [role="textbox"]').keydown(function (ev) {
           if (ev.keyCode === 13 && (ev.metaKey || ev.ctrlKey)) {
             send();
           }
         });
 
-        $('#test6 button').click(function () {
+        $('#test4 button').click(function () {
           send();
         });
       }());
 
-      // Tase case 8: Yahoo mail
+      // Tase case 6: Yahoo mail
       // Yahoo mail converts the Privly link into a hyperlink
       // Comments below are the original code from Yahoo mail
       // 
@@ -269,7 +249,7 @@
           return s.setStart(t,n),s.setEnd(t,r),window.getSelection().removeAllRanges(),window.getSelection().addRange(s),i.indexOf("http")!==0&&(i="http://"+i),i=i.replace('"',"%22").replace("'","%27"),s.deleteContents(),u=document.createElement("a"),u.href=i,u.innerHTML=escapeHtml(o),s.insertNode(u),(a=document.createRange(),a.setStart(u,0),a.setEnd(u,1),window.getSelection().removeAllRanges(),window.getSelection().addRange(a)),window.getSelection().collapseToEnd(),u
         }
 
-        $('#test8 > div').on('keydown paste', function (ev) {
+        $('#test6 > div').on('keydown paste', function (ev) {
           if (ev.type === 'paste' || ev.type === 'keydown' && (ev.keyCode === 13 || ev.keyCode === 32)) {
             // process hyperlinks
             // from Yahoo mail
@@ -309,28 +289,25 @@
 <body> 
 
   <div id="test_area">
-    <h1>Privly Embed-posting Proxy Test File</h1>
-    <p>This file contains a test cases for different circumstances in which the Privly embed-posting dialog should correctly show submiting button and forward ENTER keyboard events.</p>
-    <p>Test cases are intended to be tested automatically.<br>To test it manually, please click the Privly posting button in each editable element to pop up the embed-posting dialog. Detailed expectations are listed in each test case.</p>
+    <h1>Privly Seamless-posting Keyboard Forwarding Test File</h1>
+    <p>This file contains a test cases for different circumstances in which the Privly seamless-posting form should correctly forward ENTER keyboard events.</p>
+    <p>Test cases are intended to be tested automatically.<br>To test it manually, please click the Privly posting button in each editable element to start seamless-posting mode. Detailed expectations are listed in each test case.</p>
     
     <h3>General Test</h3>
     <p>Tests below simulate circumstances of the specific website. The purpose is to test embed-posting in the real world.</p>
 
     <h4>1. Facebook status</h4>
-    <p>You should see submit button in embed-posting dialog (caption: <em>发布</em>).<br>
-       You should see <em>submitted</em> when: <em>Command+ENTER</em> (Mac OS), <em>Control+ENTER</em> (Other OS).</p>
+    <p>You should see <em>submitted</em> when: <em>Command+ENTER</em> (Mac OS), <em>Control+ENTER</em> (Other OS).</p>
     <div id="test1">
       <form rel="async" method="post">
         <textarea role="textbox" class="textbox"></textarea>
-        <button value="1" type="submit" class="button">发布</button>
+        <button value="1" type="submit" class="button">Publish</button>
       </form>
     </div>
     <br><hr>
 
     <h4>2. Facebook chat</h4>
-    <p>You should <em>NOT</em> see submit button in embed-posting dialog.<br>
-       You should see <em>Done</em> button in embed-posting dialog.<br>
-       You should <em>NOT</em> see <em>submitted</em> when: <em>Shift+ENTER</em>.<br>
+    <p>You should <em>NOT</em> see <em>submitted</em> when: <em>Shift+ENTER</em>.<br>
        You should see <em>submitted</em> when: <em>(Any other)+ENTER</em>.<br>
      </p>
     <div id="test2">
@@ -340,8 +317,7 @@
 
     <h4>3. GitHub</h4>
     <p>GitHub only listens keydown event when the textarea is focused. This test case simulate this circumstance.</p>
-    <p>You should see submit button in embed-posting dialog (caption: <em>Comment on this commit</em>).<br>
-       You should see <em>submitted</em> when: <em>Command+ENTER</em> or <em>Control+ENTER</em>.</p>
+    <p>You should see <em>submitted</em> when: <em>Command+ENTER</em> or <em>Control+ENTER</em>.</p>
     <div id="test3">
       <form accept-charset="UTF-8" data-remote="true" method="post">
         <textarea required class="textbox"></textarea>
@@ -350,29 +326,9 @@
     </div>
     <br><hr>
 
-    <h4>4. Google Groups / Google Mail</h4>
-    <p>You should <em>NOT</em> see submit button in embed-posting dialog.<br>
-       You should see <em>Done</em> button in embed-posting dialog.</p>
+    <h4>4. Twitter</h4>
+    <p>You should see <em>submitted</em> when: <em>Command+ENTER</em> or <em>Control+ENTER</em>.</p>
     <div id="test4">
-      <div g_editable="true" role="textbox" contenteditable="true" aria-multiline="true" class="textbox"></div>
-      <div role="button" class="button"><span>Post</span></div>
-    </div>
-    <br><hr>
-
-    <h4>5. Google Plus</h4>
-    <p>You should <em>NOT</em> see submit button in embed-posting dialog.<br>
-       You should see <em>Done</em> button in embed-posting dialog.</p>
-    <div id="test5">
-      <div g_editable="true" role="textbox" contenteditable="plaintext-only" class="textbox"></div>
-      <div role="button" class="button">Share</div>
-    </div>
-    <br><hr>
-
-    <h4>6. Twitter</h4>
-    <p>You should <em>NOT</em> see submit button in embed-posting dialog.<br>
-       You should see <em>Done</em> button in embed-posting dialog.<br>
-       You should see <em>submitted</em> when: <em>Command+ENTER</em> or <em>Control+ENTER</em>.</p>
-    <div id="test6">
       <form>
         <div contenteditable="true" role="textbox" style="height: 30px;" class="textbox"><div><br></div></div>
         <button type="button" class="button">Tweet</button>
@@ -383,18 +339,18 @@
     <h3>Edge Test</h3>
     <p>Tests below only contain specific environments in which embed-posting once failed. The purpose is to make sure embed-posting really works in those edge cases and doesn't fail again.</p>
 
-    <h4>7. Live Mail / Baidu Tieba</h4>
+    <h4>5. Live Mail / Baidu Tieba</h4>
     <p>It once failed because Privly injection functionality tried to parse the Privly link inserted by embed-posting (inside &lt;p&gt; in the contentEditable element) and generated a wrong hyperlink.</p>
-    <p>You should <em>NOT</em> see embed-posting dialog auto closed.</p>
-    <div id="test7">
+    <p>You should <em>NOT</em> see seamless-posting form auto closed.</p>
+    <div id="test5">
       <div contenteditable="true" class="textbox"><p><br></p></div>
     </div>
     <br><hr>
 
-    <h4>8. Yahoo Mail</h4>
+    <h4>6. Yahoo Mail</h4>
     <p>It once failed because Yahoo Mail changed it into a hyperlink (which converts &amp; into &amp;amp;).</p>
-    <p>You should <em>NOT</em> see embed-posting dialog auto closed.</p>
-    <div id="test8">
+    <p>You should <em>NOT</em> see seamless-posting form auto closed.</p>
+    <div id="test6">
       <div contenteditable="true" class="textbox"><p><br></p></div>
     </div>
     <br>


### PR DESCRIPTION
This page can be reused for testing the posting process as well. But the level 1 iframe won't display in Firefox, so I've made the necessary changes which works for both Chrome and Firefox. Level 2 still doesn't work for Firefox, I couldn't find a way to get it to work. 
I've also added id's to make it easier to find the nodes while testing.